### PR TITLE
make k8sPlugin running on latest Steward

### DIFF
--- a/k8sPlugin/Jenkinsfile
+++ b/k8sPlugin/Jenkinsfile
@@ -4,8 +4,8 @@ podTemplate(
         containerTemplate(
             name: 'maven',
             image: 'maven:3.6.2-jdk-8',
-            runAsUser: 1000,
-            runAsGroup: 1000,
+            runAsUser: '1000',
+            runAsGroup: '1000',
             ttyEnabled: true,
             command: 'tail',
             args: '-f /dev/null',
@@ -13,8 +13,8 @@ podTemplate(
         containerTemplate(
             name: 'golang',
             image: 'golang:1.13.3',
-            runAsUser: 1000,
-            runAsGroup: 1000,
+            runAsUser: '1000',
+            runAsGroup: '1000',
             ttyEnabled: true,
             command: 'tail',
             args: '-f /dev/null',

--- a/k8sPlugin/Jenkinsfile
+++ b/k8sPlugin/Jenkinsfile
@@ -17,7 +17,6 @@ podTemplate(
           - /dev/null
           command:
           - tail
-          tty: true
         - name: golang
           image: golang:1.13.3
           command:
@@ -25,7 +24,6 @@ podTemplate(
           args:
           - -f
           - /dev/null
-          tty: true
           volumeMounts:
           - name: golang-cache
             mountPath: /.cache

--- a/k8sPlugin/Jenkinsfile
+++ b/k8sPlugin/Jenkinsfile
@@ -26,6 +26,13 @@ podTemplate(
           - -f
           - /dev/null
           tty: true
+          volumeMounts:
+          - name: golang-cache
+            mountPath: /.cache
+        volumes:
+        - name: golang-cache
+          emptyDir:
+            sizeLimit: 100Mi
     '''.stripIndent(),
 ) {
     node(POD_LABEL) {

--- a/k8sPlugin/Jenkinsfile
+++ b/k8sPlugin/Jenkinsfile
@@ -1,9 +1,26 @@
 //Inspired by: https://github.com/jenkinsci/kubernetes-plugin/blob/master/README.md#container-group-support
-podTemplate(containers: [
-    containerTemplate(name: 'maven', image: 'maven:3.6.2-jdk-8', ttyEnabled: true, command: 'cat'),
-    containerTemplate(name: 'golang', image: 'golang:1.13.3', ttyEnabled: true, command: 'cat')
-  ]) {
-
+podTemplate(
+    containers: [
+        containerTemplate(
+            name: 'maven',
+            image: 'maven:3.6.2-jdk-8',
+            runAsUser: 1000,
+            runAsGroup: 1000,
+            ttyEnabled: true,
+            command: 'tail',
+            args: '-f /dev/null',
+        ),
+        containerTemplate(
+            name: 'golang',
+            image: 'golang:1.13.3',
+            runAsUser: 1000,
+            runAsGroup: 1000,
+            ttyEnabled: true,
+            command: 'tail',
+            args: '-f /dev/null',
+        ),
+    ],
+) {
     node(POD_LABEL) {
         stage('Get a Maven project') {
             git 'https://github.com/jenkins-docs/simple-java-maven-app.git'
@@ -35,6 +52,5 @@ podTemplate(containers: [
                 }
             }
         }
-
     }
 }

--- a/k8sPlugin/Jenkinsfile
+++ b/k8sPlugin/Jenkinsfile
@@ -1,25 +1,32 @@
 //Inspired by: https://github.com/jenkinsci/kubernetes-plugin/blob/master/README.md#container-group-support
 podTemplate(
-    containers: [
-        containerTemplate(
-            name: 'maven',
-            image: 'maven:3.6.2-jdk-8',
-            runAsUser: '1000',
-            runAsGroup: '1000',
-            ttyEnabled: true,
-            command: 'tail',
-            args: '-f /dev/null',
-        ),
-        containerTemplate(
-            name: 'golang',
-            image: 'golang:1.13.3',
-            runAsUser: '1000',
-            runAsGroup: '1000',
-            ttyEnabled: true,
-            command: 'tail',
-            args: '-f /dev/null',
-        ),
-    ],
+    yaml: '''\
+      apiVersion: v1
+      kind: Pod
+      spec:
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          fsGroup: 1000
+        automountServiceAccountToken: false
+        containers:
+        - name: maven
+          image: maven:3.6.2-jdk-8
+          args:
+          - -f
+          - /dev/null
+          command:
+          - tail
+          tty: true
+        - name: golang
+          image: golang:1.13.3
+          command:
+          - tail
+          args:
+          - -f
+          - /dev/null
+          tty: true
+    '''.stripIndent(),
 ) {
     node(POD_LABEL) {
         stage('Get a Maven project') {


### PR DESCRIPTION
- run as user/group 1000
- cope with read-only root filesystem
- use `tail` instead of `cat` to keep container running